### PR TITLE
解决 __45-[GKPhotoGestureHandler browserCancelDismiss]_block_invoke.55 崩溃问题

### DIFF
--- a/GKPhotoBrowser/Core/GKPhotoGestureHandler.h
+++ b/GKPhotoBrowser/Core/GKPhotoGestureHandler.h
@@ -37,7 +37,7 @@ typedef NS_ENUM(NSUInteger, GKPanGestureRecognizerDirection) {
 
 @interface GKPhotoGestureHandler : GKPhotoBrowserHandler
 
-@property (nonatomic, assign) id<GKPhotoGestureDelegate> delegate;
+@property (nonatomic, weak) id<GKPhotoGestureDelegate> delegate;
 
 @property (nonatomic, strong) UITapGestureRecognizer *singleTapGesture;
 @property (nonatomic, strong) UITapGestureRecognizer *doubleTapGesture;


### PR DESCRIPTION
更新新版后出现大量bug，如图
![WX20230414-150026](https://user-images.githubusercontent.com/7042430/231968021-4c52212d-73ea-4dee-bfc3-93739f1edb70.png)
后排查是因为delegate关键字使用assign的导致释放后调用就崩溃的原因