### PR TITLE
修复一个图片叠加问题

### DIFF
--- a/GKPhotoBrowser/Core/GKPhotoBrowser.m
+++ b/GKPhotoBrowser/Core/GKPhotoBrowser.m
@@ -553,6 +553,7 @@ static Class progressClass = nil;
         [_reusablePhotoViews removeObject:photoView];
     }else {
         photoView = [[GKPhotoView alloc] initWithFrame:self.photoScrollView.bounds imageProtocol:_imageProtocol];
+        photoView.clipsToBounds = YES;
     }
     photoView.tag = -1;
     return photoView;


### PR DESCRIPTION
问题已经具体描述在Issues中，以下是问题简略描述
选择任意高度小于屏幕的图片，双指拖拽放大，但不能放大到图片高度超过屏幕，要保留上下一定的黑边，左右超过屏幕宽度，并且图片处于中间位置（即图片左右两侧均超过屏幕），然后在屏幕左下角以一种斜向上的方向快速滑动，然后出现图片叠加问题