### PR TITLE
修复因修改图片叠加而导致的消失动画出错问题

### DIFF
--- a/GKPhotoBrowser/Core/GKPhotoGestureHandler.m
+++ b/GKPhotoBrowser/Core/GKPhotoGestureHandler.m
@@ -315,7 +315,7 @@ int const static kDirectionPanThreshold = 5;
     GKPhotoView *photoView = self.browser.curPhotoView;
     if (!photoView) return;
     photoView.imageView.clipsToBounds = YES;
-    
+    photoView.clipsToBounds = NO;
     GKPhoto *photo = photoView.photo;
     if (self.browser.isHideSourceView) {
         photo.sourceImageView.alpha = 0;


### PR DESCRIPTION
在GKPhotoGestureHandler -(void)handlePanBegin 方法种增加了设置photoView.clipsToBounds = NO;的代码，避免拖拽消失时候导致的动画过程中断消失，具体描述已经写在Issues种